### PR TITLE
Remove unused translation for checking category description

### DIFF
--- a/ems_translations.csv
+++ b/ems_translations.csv
@@ -783,4 +783,3 @@ Mobile phone number;Mobiel telefoonnummer;Numéro de téléphone mobile;Nummer d
 Street name;Straatnaam;Nom de rue;Straßenname;Gatunamn;Nazwa ulicy
 This configuration is not possible. Your last change could not be saved.;Deze configuratie is niet mogelijk. Je laatste wijziging kon niet worden opgeslagen.;Cette configuration n'est pas possible. Votre dernière modification n'a pas pu être enregistrée.;Diese Konfiguration ist nicht möglich. Ihre letzte Änderung konnte nicht gespeichert werden.;;
 The issue could be caused by a change in the parent configuration.;De issue zou veroorzaakt kunnen zijn door een wijziging in een parent configuratie.;Le problème peut être causé par un changement dans la configuration parente.;Das Problem könnte durch eine Änderung in der übergeordneten Konfiguration verursacht werden.;;
-The description contains illegal characters.;;;;;


### PR DESCRIPTION
From what I was told, @AJJPostma has already fixed this bug previously. I only removed the unused translation that was left over.