### PR TITLE
nice batch file to get the line which is wrong

### DIFF
--- a/scripts/character_count.bat
+++ b/scripts/character_count.bat
@@ -1,0 +1,12 @@
+@ECHO OFF
+SET "inputFile=.\ems_translations.csv"
+powershell -NoLogo -NoProfile -Command ^
+    "$counter = 0;" ^
+    "Get-Content -Path '%inputFile%' |" ^
+        "ForEach-Object {" ^
+            "$counter++;" ^
+            "$ns = $_ -replace ';','';" ^
+            "if (($_.Length - $ns.Length) -ne 11) {" ^
+                "'Iteration {0}: Length is {1}' -f $counter, ($_.Length - $ns.Length)" ^
+            "}" ^
+        "}"


### PR DESCRIPTION
a batch file to run to get the line where the delimiters are wrong. Please change when more translations are added