### PR TITLE
updated translation workflows to use a non deprecated ubuntu version.

### DIFF
--- a/.github/workflows/check-column-count.yml
+++ b/.github/workflows/check-column-count.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check column count'
-    runs-on: ubuntu-2204-4
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/check-column-count.yml
+++ b/.github/workflows/check-column-count.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check column count'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-2204-4
 
     defaults:
       run:

--- a/.github/workflows/check-duplicate-keys.yml
+++ b/.github/workflows/check-duplicate-keys.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check duplicate keys'
-    runs-on: ubuntu-2204-4
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/check-duplicate-keys.yml
+++ b/.github/workflows/check-duplicate-keys.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check duplicate keys'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-2204-4
 
     defaults:
       run:

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check encoding'
-    runs-on: ubuntu-2204-4
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/check-encoding.yml
+++ b/.github/workflows/check-encoding.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check encoding'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-2204-4
 
     defaults:
       run:

--- a/.github/workflows/check-header-column.yml
+++ b/.github/workflows/check-header-column.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check headers'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-2204-4
 
     defaults:
       run:

--- a/.github/workflows/check-header-column.yml
+++ b/.github/workflows/check-header-column.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: 'Check headers'
-    runs-on: ubuntu-2204-4
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/dispatch-updates.yaml
+++ b/.github/workflows/dispatch-updates.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify:
     name: 'Submodule Notify Parent'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-2204-4
 
     defaults:
       run:

--- a/.github/workflows/dispatch-updates.yaml
+++ b/.github/workflows/dispatch-updates.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify:
     name: 'Submodule Notify Parent'
-    runs-on: ubuntu-2204-4
+    runs-on: ubuntu-latest
 
     defaults:
       run:


### PR DESCRIPTION
ubuntu-20.04 is deprecated for github workflows as of 15.04.2025, which this fixes by using the latest version.